### PR TITLE
Allow to set filename only ID's

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ class Service {
     const hash = bufferToHash(buffer);
     const ext = mimeTypes.extension(contentType);
     id = id || `${hash}.${ext}`;
+    if(id.indexOf('.') === -1) id += '.' + ext; //attach extension if not provided
 
     fromBuffer(buffer)
     .pipe(this.Model.createWriteStream({


### PR DESCRIPTION
Currently either one completely parses the URI again and thus knows what extension to set in the ID field, or uses the default. There is no way to only set the filename and automatically set the extension. This added line will make sure, that the extension is appended, if the user only provided e.g. "myfancyname" as the ID.