### PR TITLE
return deleted id to avoid 404 error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ class Service {
     return new Promise((resolve, reject) => {
       this.Model.remove({
         key: id
-      }, error => (error, result) ? reject(error) : resolve({ id }));
+      }, error => error ? reject(error) : resolve({ id }));
     });
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -33,16 +33,16 @@ class Service {
       this.Model.createReadStream({
         key: id
       })
-        .on('error', reject)
-        .pipe(toBuffer(buffer => {
-          const uri = getBase64DataURI(buffer, contentType);
+      .on('error', reject)
+      .pipe(toBuffer(buffer => {
+        const uri = getBase64DataURI(buffer, contentType);
 
-          resolve({
-            [this.id]: id,
-            uri,
-            size: buffer.length
-          });
-        }));
+        resolve({
+          [this.id]: id,
+          uri,
+          size: buffer.length
+        });
+      }));
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,16 +33,16 @@ class Service {
       this.Model.createReadStream({
         key: id
       })
-      .on('error', reject)
-      .pipe(toBuffer(buffer => {
-        const uri = getBase64DataURI(buffer, contentType);
+        .on('error', reject)
+        .pipe(toBuffer(buffer => {
+          const uri = getBase64DataURI(buffer, contentType);
 
-        resolve({
-          [this.id]: id,
-          uri,
-          size: buffer.length
-        });
-      }));
+          resolve({
+            [this.id]: id,
+            uri,
+            size: buffer.length
+          });
+        }));
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ class Service {
     return new Promise((resolve, reject) => {
       this.Model.remove({
         key: id
-      }, error => error ? reject(error) : resolve());
+      }, error => (error, result) ? reject(error) : resolve({ id }));
     });
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,7 +41,7 @@ describe('feathers-blob-store', () => {
       // test successful remove
       return store.remove(contentId);
     }).then(res => {
-      assert.equal(res, {id: contentId});
+      assert.deepEqual(res, {id: contentId});
 
       // test failing get
       return store.get(contentId)
@@ -79,7 +79,7 @@ describe('feathers-blob-store', () => {
       // test successful remove
       return store.remove(contentId);
     }).then(res => {
-      assert.equal(res, {id: contentId});
+      assert.deepEqual(res, {id: contentId});
 
       // test failing get
       return store.get(contentId).catch(err =>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,7 +41,7 @@ describe('feathers-blob-store', () => {
       // test successful remove
       return store.remove(contentId);
     }).then(res => {
-      assert.equal(res, null);
+      assert.equal(res, {id: contentId});
 
       // test failing get
       return store.get(contentId)
@@ -79,7 +79,7 @@ describe('feathers-blob-store', () => {
       // test successful remove
       return store.remove(contentId);
     }).then(res => {
-      assert.equal(res, null);
+      assert.equal(res, {id: contentId});
 
       // test failing get
       return store.get(contentId).catch(err =>


### PR DESCRIPTION
### Summary

Issue:
returning an empty promise results in a 404 error even when the delete was successful.

Resolution:

Returning an object with the id resolves this issue