### PR TITLE
Added support to create blob from raw buffer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { extname } from 'path';
 import Proto from 'uberproto';
-// import errors from 'feathers-errors';
+import errors from 'feathers-errors';
 import { getBase64DataURI, parseDataURI } from 'dauria';
 import toBuffer from 'concat-stream';
 import mimeTypes from 'mime-types';
@@ -47,8 +47,17 @@ class Service {
   }
 
   create (body, params = {}) {
-    let { id, uri } = body;
-    const { buffer, MIME: contentType } = parseDataURI(uri);
+    let { id, uri, buffer, contentType } = body;
+    if (uri) {
+      const result = parseDataURI(uri);
+      contentType = result.MIME;
+      buffer = result.buffer;
+    } else {
+      uri = getBase64DataURI(buffer, contentType);
+    }
+    if (!uri || !buffer || !contentType) {
+      throw new errors.BadRequest('Buffer or URI with valid content type must be provided to create a blob');
+    }
     const hash = bufferToHash(buffer);
     const ext = mimeTypes.extension(contentType);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,7 +17,7 @@ describe('feathers-blob-store', () => {
     assert.equal(typeof require('../lib'), 'function');
   });
 
-  it('basic functionality', () => {
+  it('basic functionality with data URI', () => {
     assert.equal(typeof BlobService, 'function', 'exports factory function');
 
     const blobStore = FsBlobStore(join(__dirname, 'blobs'));
@@ -28,6 +28,39 @@ describe('feathers-blob-store', () => {
     const contentId = `${contentHash}.${contentExt}`;
 
     return store.create({ uri: contentUri }).then(res => {
+      assert.equal(res.id, contentId);
+      assert.equal(res.uri, contentUri);
+      assert.equal(res.size, content.length);
+
+      // test successful get
+      return store.get(contentId);
+    }).then(res => {
+      assert.equal(res.id, contentId);
+      assert.equal(res.uri, contentUri);
+      assert.equal(res.size, content.length);
+
+      // test successful remove
+      return store.remove(contentId);
+    }).then(res => {
+      assert.deepEqual(res, {id: contentId});
+
+      // test failing get
+      return store.get(contentId)
+        .catch(err => assert.ok(err, '.get() to non-existent id should error'));
+    });
+  });
+
+  it('basic functionality with buffer', () => {
+    assert.equal(typeof BlobService, 'function', 'exports factory function');
+
+    const blobStore = FsBlobStore(join(__dirname, 'blobs'));
+    const store = BlobService({
+      Model: blobStore
+    });
+
+    const contentId = `${contentHash}.${contentExt}`;
+
+    return store.create({ buffer: content, contentType }).then(res => {
       assert.equal(res.id, contentId);
       assert.equal(res.uri, contentUri);
       assert.equal(res.size, content.length);


### PR DESCRIPTION
Partly covering https://github.com/feathersjs-ecosystem/feathers-blob/issues/25 but with a less "intrusive" approach, ie not specifically bound to a particular parameter provided by multer or other middlewares. In that way the buffer can be directly provided in the request from the socket for instance.

For now the output interface is still providing a data URI in any cases so that there is no API change. Maybe in the future when creating from a raw buffer a buffer could be returned.
 

