### PR TITLE
Feat: use params for get operation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,8 @@ class Service {
 
     return new Promise((resolve, reject) => {
       this.Model.createReadStream({
-        key: id
+        key: id,
+        params: params.s3
       })
         .on('error', reject)
         .pipe(toBuffer(buffer => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ class Service {
     return Proto.extend(obj, this);
   }
 
-  get (id) {
+  get (id, params = {}) {
     const ext = extname(id);
     const contentType = mimeTypes.lookup(ext);
 


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
Currently you can set params.s3 object that will passed to the create op. For example this allows to specify an S3 Bucket where the blob should be uploaded to. But the get operation does not respect the params. So you can store a blob in a bucket you specify but you cannot retreive it.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?
No

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: