### PR TITLE
feat: make data uri encoding optional

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,8 @@ class Service {
       throw new Error('feathers-blob-store: constructor `options.Model` must be provided');
     }
 
+    this.returnBuffer = options.returnBuffer || false;
+    this.returnUri = options.returnUri !== false;
     this.Model = options.Model;
     this.id = options.id || 'id';
   }
@@ -41,9 +43,9 @@ class Service {
     // Unrecognized mime type
     if ((typeof contentType === 'boolean') && !contentType) {
       // Fallback to binary content
-      contentType = 'application/octet-stream'
+      contentType = 'application/octet-stream';
     }
-    debug(`Retrieving blob ${id} with ext ${ext} and content type ${contentType}`)
+    debug(`Retrieving blob ${id} with ext ${ext} and content type ${contentType}`);
 
     return new Promise((resolve, reject) => {
       this.Model.createReadStream({
@@ -52,11 +54,12 @@ class Service {
       })
         .on('error', reject)
         .pipe(toBuffer(buffer => {
-          const uri = getBase64DataURI(buffer, contentType);
-
           resolve({
             [this.id]: id,
-            uri,
+            ...(this.returnBuffer && { buffer }),
+            ...(this.returnUri && {
+              uri: getBase64DataURI(buffer, contentType)
+            }),
             size: buffer.length
           });
         }));
@@ -65,29 +68,32 @@ class Service {
 
   create (body, params = {}) {
     let { id, uri, buffer, contentType } = body;
-    if (uri) {
-      const result = parseDataURI(uri);
-      contentType = result.MIME;
-      buffer = result.buffer;
-    } else {
-      uri = getBase64DataURI(buffer, contentType);
+    if (this.returnUri) {
+      if (uri) {
+        const result = parseDataURI(uri);
+        contentType = result.MIME;
+        buffer = result.buffer;
+      } else {
+        uri = getBase64DataURI(buffer, contentType);
+      }
     }
-    if (!uri || !buffer || !contentType) {
+
+    if (!uri && (!buffer || !contentType)) {
       throw new errors.BadRequest('Buffer or URI with valid content type must be provided to create a blob');
     }
     const hash = bufferToHash(buffer);
     let ext = mimeTypes.extension(contentType);
-    
+
     // Unrocognized mime type
     if ((typeof ext === 'boolean') && !ext) {
       // Fallback to binary content
-      ext = 'bin'
-      contentType = 'application/octet-stream'
+      ext = 'bin';
+      contentType = 'application/octet-stream';
     }
 
     id = id || `${hash}.${ext}`;
 
-    debug(`Creating blob ${id} with ext ${ext} and content type ${contentType}`)
+    debug(`Creating blob ${id} with ext ${ext} and content type ${contentType}`);
     return new Promise((resolve, reject) => {
       fromBuffer(buffer)
         .pipe(this.Model.createWriteStream({
@@ -98,7 +104,8 @@ class Service {
             ? reject(error)
             : resolve({
               [this.id]: id,
-              uri,
+              ...(this.returnBuffer && { buffer }),
+              ...(this.returnUri && { uri }),
               size: buffer.length
             })
         ))
@@ -107,7 +114,7 @@ class Service {
   }
 
   remove (id) {
-    debug(`Removing blob ${id}`)
+    debug(`Removing blob ${id}`);
     return new Promise((resolve, reject) => {
       this.Model.remove({
         key: id

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ class Service {
     }
 
     this.returnBuffer = options.returnBuffer || false;
-    this.returnUri = options.returnUri !== false;
+    this.returnUri = !options.returnBuffer;
     this.Model = options.Model;
     this.id = options.id || 'id';
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,6 +105,38 @@ describe('feathers-blob-store-basic', () => {
     });
   });
 
+  it('service operations with returnBuffer=true and returnUri=false', () => {
+    const store = BlobService({
+      Model: blobStore,
+      returnBuffer: true,
+      returnUri: false
+    });
+
+    return store.create({ buffer: content, contentType }).then(res => {
+      assert.strictEqual(res.id, contentId);
+      assert.strictEqual(res.buffer.equals(content), true);
+      assert.strictEqual(res.uri, undefined);
+      assert.strictEqual(res.size, content.length);
+
+      // test successful get
+      return store.get(contentId);
+    }).then(res => {
+      assert.strictEqual(res.id, contentId);
+      assert.strictEqual(res.buffer.equals(content), true);
+      assert.strictEqual(res.uri, undefined);
+      assert.strictEqual(res.size, content.length);
+
+      // test successful remove
+      return store.remove(contentId);
+    }).then(res => {
+      assert.deepStrictEqual(res, { id: contentId });
+
+      // test failing get
+      return store.get(contentId)
+        .catch(err => assert.ok(err, '.get() to non-existent id should error'));
+    });
+  });
+
   it('service operations with custom output id field', () => {
     const store = BlobService({
       Model: blobStore,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,11 +105,10 @@ describe('feathers-blob-store-basic', () => {
     });
   });
 
-  it('service operations with returnBuffer=true and returnUri=false', () => {
+  it('service operations with returnBuffer=true', () => {
     const store = BlobService({
       Model: blobStore,
-      returnBuffer: true,
-      returnUri: false
+      returnBuffer: true
     });
 
     return store.create({ buffer: content, contentType }).then(res => {


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x ] Tell us about the problem your pull request is solving.
As stated by @claustres:

> Data uri is great to typically upload/download images, however for others types of data like raw binary data, etc. it adds a layer of complexity that is not really useful.
> 
> The usage of data uri could remains default (backward compatibility) but the usage of raw data buffer could be enforced by either a service constructor option or a query parameter.

- [x] Are there any open issues that are related to this?
Closes #71  and #69 

- [x] Is this PR dependent on PRs in other repos?
No

If so, please mention them to keep the conversations linked together.

### Other Information
Sorry about the additional formatting (was the specified lint command).