### PR TITLE
Small optimization to `create()`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,6 @@ class Service {
     if (!uri && (!buffer || !contentType)) {
       throw new errors.BadRequest('Buffer or URI with valid content type must be provided to create a blob');
     }
-    const hash = bufferToHash(buffer);
     let ext = mimeTypes.extension(contentType);
 
     // Unrocognized mime type
@@ -91,7 +90,10 @@ class Service {
       contentType = 'application/octet-stream';
     }
 
-    id = id || `${hash}.${ext}`;
+    if (!id) {
+      const hash = bufferToHash(buffer);
+      id = `${hash}.${ext}`;
+    }
 
     debug(`Creating blob ${id} with ext ${ext} and content type ${contentType}`);
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This makes it so we don't recompute the hash when we don't need to.

This doesn't fix any urgent or dire problem. It is just a little optimization.

Note that this will cause even more conflicts with https://github.com/feathersjs-ecosystem/feathers-blob/pull/13
