### PR TITLE
Fix option returnUri to have false value

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ Also install a [`abstract-blob-store` compatible module](https://github.com/maxo
 
 - `options.Model` is an instantiated interface [that implements the `abstract-blob-store` API](https://github.com/maxogden/abstract-blob-store#api)
 - `options.id` is a string 'key' for the blob identifier.
-- `returnUri` defaults to `true` and indicates if the service output a data URI on create/get operations 
-- `returnBuffer` set it to `true` if you only want a buffer output instead of a data URI on create/get operations 
+- `returnUri` defaults is `true`, set it to `false` to remove it from output.
+- `returnBuffer` defaults is `false` , set it to `true` to return buffer in the output. 
 
-**Tip**: `returnUri`/`returnBuffer` are mutually exclusive. If you need both extract the buffer from the data URI on the client-side to avoid transferring the data twice over the wire.
+**Tip**: `returnUri`/`returnBuffer` are mutually exclusive.
+
+If you only want a buffer output instead of a data URI on create/get operations, you need to set `returnBuffer` to be `true`, also to set `retuarnUri` to be `false`.
+
+If you need both, use the default options, then extract the buffer from the data URI on the client-side to avoid transferring the data twice over the wire.
 
 ### `blobService.create(body, params)`
 
@@ -48,8 +52,8 @@ returns output 'data' of the form:
 ```js
 {
   [this.id]: `${hash(content)}.${extension(contentType)}`,
-  uri: body.uri, // When returnUri options is set
-  buffer: body.buffer, // When returnBuffer options is set
+  uri: body.uri, // When returnUri options is set true
+  buffer: body.buffer, // When returnBuffer options is set true
   size: length(content)
 }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ class Service {
     }
 
     this.returnBuffer = options.returnBuffer || false;
-    this.returnUri = !options.returnBuffer;
+    this.returnUri = options.returnUri !== undefined ? options.returnUri : true;
     this.Model = options.Model;
     this.id = options.id || 'id';
   }
@@ -68,14 +68,12 @@ class Service {
 
   create (body, params = {}) {
     let { id, uri, buffer, contentType } = body;
-    if (this.returnUri) {
-      if (uri) {
-        const result = parseDataURI(uri);
-        contentType = result.MIME;
-        buffer = result.buffer;
-      } else {
-        uri = getBase64DataURI(buffer, contentType);
-      }
+    if (uri) {
+      const result = parseDataURI(uri);
+      contentType = result.MIME;
+      buffer = result.buffer;
+    } else {
+      uri = getBase64DataURI(buffer, contentType);
     }
 
     if (!uri && (!buffer || !contentType)) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -106,7 +106,8 @@ describe('feathers-blob-store-basic', () => {
   it('service operations with buffer output', async () => {
     const store = BlobService({
       Model: blobStore,
-      returnBuffer: true
+      returnBuffer: true,
+      returnUri: false
     });
 
     let res = await store.create({ buffer: content, contentType });
@@ -119,6 +120,37 @@ describe('feathers-blob-store-basic', () => {
     res = await store.get(contentId);
     assert.strictEqual(res.id, contentId);
     assert.strictEqual(res.buffer.equals(content), true);
+    assert.strictEqual(res.uri, undefined);
+    assert.strictEqual(res.size, content.length);
+
+    // test successful remove
+    res = await store.remove(contentId);
+    assert.deepStrictEqual(res, { id: contentId });
+
+    try {
+      // test failing get
+      await store.get(contentId);
+    } catch (err) {
+      assert.ok(err, '.get() to non-existent id should error');
+    }
+  });
+
+  it('service operations without uri output', async () => {
+    const store = BlobService({
+      Model: blobStore,
+      returnUri: false
+    });
+
+    let res = await store.create({ buffer: content, contentType });
+    assert.strictEqual(res.id, contentId);
+    assert.strictEqual(res.buffer, undefined);
+    assert.strictEqual(res.uri, undefined);
+    assert.strictEqual(res.size, content.length);
+
+    // test successful get
+    res = await store.get(contentId);
+    assert.strictEqual(res.id, contentId);
+    assert.strictEqual(res.buffer, undefined);
     assert.strictEqual(res.uri, undefined);
     assert.strictEqual(res.size, content.length);
 


### PR DESCRIPTION
This makes `returnUri` option could have false value to have output to be without `uri` property

Issue related:
#75 
