### PR TITLE
feat(s3): add support for fetching versioned bucket items

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ returns output `data` of the same form as `create`.
 
 ### `blobService.remove(id, params)`
 
+#### Params:
+
+Query: 
+
+ - `VersionId` (string): Version ID of document to access if using a versioned s3 bucket
+
+Example: 
+
+```js 
+blobService.get('my-file.pdf', {
+  query: {VersionId: 'xslkdfjlskdjfskljf.sdjfdkjfkdjfd'},
+})
+```
+
 ## Example
 
 ```js
@@ -113,6 +127,11 @@ app.service('upload').before({
 
 For a more complete example, see [examples/app](./examples/app.js) which can be run with `npm run example`.
 
+## Tests
+
+Tests can be run by installing the node modules and running `npm run test`. 
+
+To test the S3 read/write capabilities set the environmental variable `S3_BUCKET` to the name of a bucket you have read/write access to. Enable the versioning functionality on the bucket. 
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,11 @@ class Service {
   }
 
   get (id, params = {}) {
+    const s3Params = {
+      ...params.s3,
+      VersionId: (params.query && params.query.VersionId) ? params.query.VersionId : undefined
+    };
+
     const ext = extname(id);
     let contentType = mimeTypes.lookup(ext);
     // Unrecognized mime type
@@ -50,7 +55,7 @@ class Service {
     return new Promise((resolve, reject) => {
       this.Model.createReadStream({
         key: id,
-        params: params.s3
+        params: s3Params
       })
         .on('error', reject)
         .pipe(toBuffer(buffer => {


### PR DESCRIPTION
### Summary

This pull request adds `$versionId` as a supported query parameter to allow clients to request a specific version of a key in S3. It does so by mixing in the S3 parameters with the query paramter (if provided) to provide `VersionId` to the s3 api. 

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: