### PR TITLE
Create URI from buffer only if requested

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,9 @@ class Service {
       contentType = result.MIME;
       buffer = result.buffer;
     } else {
-      uri = getBase64DataURI(buffer, contentType);
+      if (this.returnUri) {
+        uri = getBase64DataURI(buffer, contentType);
+      }
     }
 
     if (!uri && (!buffer || !contentType)) {


### PR DESCRIPTION
### Summary

When submitting a very large upload (~450MB) as a buffer, the `create` action fails with an error about max string length exceeded, even if `returnUri === false`.

I added an if-clause checking for `returnUri` before creating the `uri` value, thus skipping setting it if not requested through config.

Not sure if this would hurt existing configurations, but I don't see why `uri` would need to be set if not returned.