### PR TITLE
Allow overriding returnUri and returnBuffer with params

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,8 +1,11 @@
 const convertQueryOverrides = () => {
   return context => {
     const { query = {} } = context.params;
-    if (typeof query.returnUri === 'string') query.returnUri = Boolean(JSON.parse(query.returnUri.toLowerCase()));
-    if (typeof query.returnBuffer === 'string') query.returnBuffer = Boolean(JSON.parse(query.returnBuffer.toLowerCase()));
+    const convertQueryParam = key => {
+      if (typeof query[key] === 'string') query[key] = Boolean(JSON.parse(query[key].toLowerCase()));
+    };
+    convertQueryParam('returnUri');
+    convertQueryParam('returnBuffer');
     return context;
   };
 };

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,10 +1,11 @@
 const convertQueryOverrides = () => {
   return context => {
     const { query } = context.params;
-    if (query) {
-      const { returnUri, returnBuffer } = query;
-      if (typeof returnUri === 'string') query.returnUri = Boolean(JSON.parse(returnUri.toLowerCase()));
-      if (typeof returnBuffer === 'string') query.returnBuffer = Boolean(JSON.parse(returnBuffer.toLowerCase()));
+    if (query && typeof query.returnUri === 'string') {
+      query.returnUri = Boolean(JSON.parse(query.returnUri.toLowerCase()));
+    }
+    if (query && typeof query.returnBuffer === 'string') {
+      query.returnBuffer = Boolean(JSON.parse(query.returnBuffer.toLowerCase()));
     }
     return context;
   };

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,0 +1,15 @@
+const convertQueryOverrides = () => {
+  return context => {
+    const { query } = context.params;
+    if (query) {
+      const { returnUri, returnBuffer } = query;
+      if (typeof returnUri === 'string') query.returnUri = Boolean(JSON.parse(returnUri.toLowerCase()));
+      if (typeof returnBuffer === 'string') query.returnBuffer = Boolean(JSON.parse(returnBuffer.toLowerCase()));
+    }
+    return context;
+  };
+};
+
+module.exports = {
+  convertQueryOverrides
+};

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,12 +1,8 @@
 const convertQueryOverrides = () => {
   return context => {
-    const { query } = context.params;
-    if (query && typeof query.returnUri === 'string') {
-      query.returnUri = Boolean(JSON.parse(query.returnUri.toLowerCase()));
-    }
-    if (query && typeof query.returnBuffer === 'string') {
-      query.returnBuffer = Boolean(JSON.parse(query.returnBuffer.toLowerCase()));
-    }
+    const { query = {} } = context.params;
+    if (typeof query.returnUri === 'string') query.returnUri = Boolean(JSON.parse(query.returnUri.toLowerCase()));
+    if (typeof query.returnBuffer === 'string') query.returnBuffer = Boolean(JSON.parse(query.returnBuffer.toLowerCase()));
     return context;
   };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,12 +38,13 @@ class Service {
   }
 
   get (id, params = {}) {
+    const { query } = params;
     const s3Params = {
       ...params.s3,
-      VersionId: (params.query && params.query.VersionId) ? params.query.VersionId : undefined
+      VersionId: (query && query.VersionId) ? query.VersionId : undefined
     };
-    const returnBuffer = params.returnBuffer !== undefined ? params.returnBuffer : this.returnBuffer;
-    const returnUri = params.returnUri !== undefined ? params.returnUri : this.returnUri;
+    const returnBuffer = query && query.returnBuffer !== undefined ? query.returnBuffer : this.returnBuffer;
+    const returnUri = query && query.returnUri !== undefined ? query.returnUri : this.returnUri;
 
     const ext = extname(id);
     let contentType = mimeTypes.lookup(ext);
@@ -75,8 +76,9 @@ class Service {
   }
 
   create (body, params = {}) {
-    const returnBuffer = params.returnBuffer !== undefined ? params.returnBuffer : this.returnBuffer;
-    const returnUri = params.returnUri !== undefined ? params.returnUri : this.returnUri;
+    const { query } = params;
+    const returnBuffer = query && query.returnBuffer !== undefined ? query.returnBuffer : this.returnBuffer;
+    const returnUri = query && query.returnUri !== undefined ? query.returnUri : this.returnUri;
 
     let { id, uri, buffer, contentType } = body;
     if (uri) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,8 @@ class Service {
       ...params.s3,
       VersionId: (params.query && params.query.VersionId) ? params.query.VersionId : undefined
     };
+    const returnBuffer = params.returnBuffer !== undefined ? params.returnBuffer : this.returnBuffer;
+    const returnUri = params.returnUri !== undefined ? params.returnUri : this.returnUri;
 
     const ext = extname(id);
     let contentType = mimeTypes.lookup(ext);
@@ -61,8 +63,8 @@ class Service {
         .pipe(toBuffer(buffer => {
           resolve({
             [this.id]: id,
-            ...(this.returnBuffer && { buffer }),
-            ...(this.returnUri && {
+            ...(returnBuffer && { buffer }),
+            ...(returnUri && {
               uri: getBase64DataURI(buffer, contentType)
             }),
             size: buffer.length,
@@ -73,13 +75,16 @@ class Service {
   }
 
   create (body, params = {}) {
+    const returnBuffer = params.returnBuffer !== undefined ? params.returnBuffer : this.returnBuffer;
+    const returnUri = params.returnUri !== undefined ? params.returnUri : this.returnUri;
+
     let { id, uri, buffer, contentType } = body;
     if (uri) {
       const result = parseDataURI(uri);
       contentType = result.MIME;
       buffer = result.buffer;
     } else {
-      if (this.returnUri) {
+      if (returnUri) {
         uri = getBase64DataURI(buffer, contentType);
       }
     }
@@ -105,18 +110,18 @@ class Service {
     return new Promise((resolve, reject) => {
       fromBuffer(buffer)
         .pipe(this.Model.createWriteStream({
-          key: id,
-          params: params.s3
-        }, (error) =>
-          error
-            ? reject(error)
-            : resolve({
-              [this.id]: id,
-              ...(this.returnBuffer && { buffer }),
-              ...(this.returnUri && { uri }),
-              size: buffer.length,
-              contentType
-            })
+            key: id,
+            params: params.s3
+          }, (error) =>
+            error
+              ? reject(error)
+              : resolve({
+                [this.id]: id,
+                ...(returnBuffer && { buffer }),
+                ...(returnUri && { uri }),
+                size: buffer.length,
+                contentType
+              })
         ))
         .on('error', reject);
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,8 @@ const {
   bufferToHash
 } = require('./util');
 
+const { convertQueryOverrides } = require('./hooks');
+
 class Service {
   constructor (options) {
     if (!options) {
@@ -144,3 +146,7 @@ module.exports = function init (options) {
 };
 
 module.exports.Service = Service;
+
+module.exports.hooks = {
+  convertQueryOverrides
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,18 +113,18 @@ class Service {
     return new Promise((resolve, reject) => {
       fromBuffer(buffer)
         .pipe(this.Model.createWriteStream({
-            key: id,
-            params: params.s3
-          }, (error) =>
-            error
-              ? reject(error)
-              : resolve({
-                [this.id]: id,
-                ...(returnBuffer && { buffer }),
-                ...(returnUri && { uri }),
-                size: buffer.length,
-                contentType
-              })
+          key: id,
+          params: params.s3
+        }, (error) =>
+          error
+            ? reject(error)
+            : resolve({
+              [this.id]: id,
+              ...(returnBuffer && { buffer }),
+              ...(returnUri && { uri }),
+              size: buffer.length,
+              contentType
+            })
         ))
         .on('error', reject);
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,8 +14,7 @@ const debug = makeDebug('feathers-blob-store');
 
 const {
   fromBuffer,
-  bufferToHash,
-  queryParamIsFalsy
+  bufferToHash
 } = require('./util');
 
 class Service {
@@ -44,8 +43,8 @@ class Service {
       ...params.s3,
       VersionId: (query && query.VersionId) ? query.VersionId : undefined
     };
-    const returnBuffer = query && 'returnBuffer' in query ? !queryParamIsFalsy(query.returnBuffer) : this.returnBuffer;
-    const returnUri = query && 'returnUri' in query ? !queryParamIsFalsy(query.returnUri) : this.returnUri;
+    const returnBuffer = query && 'returnBuffer' in query ? query.returnBuffer : this.returnBuffer;
+    const returnUri = query && 'returnUri' in query ? query.returnUri : this.returnUri;
 
     const ext = extname(id);
     let contentType = mimeTypes.lookup(ext);
@@ -78,8 +77,8 @@ class Service {
 
   create (body, params = {}) {
     const { query } = params;
-    const returnBuffer = query && 'returnBuffer' in query ? !queryParamIsFalsy(query.returnBuffer) : this.returnBuffer;
-    const returnUri = query && 'returnUri' in query ? !queryParamIsFalsy(query.returnUri) : this.returnUri;
+    const returnBuffer = query && 'returnBuffer' in query ? query.returnBuffer : this.returnBuffer;
+    const returnUri = query && 'returnUri' in query ? query.returnUri : this.returnUri;
 
     let { id, uri, buffer, contentType } = body;
     if (uri) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ const debug = makeDebug('feathers-blob-store');
 
 const {
   fromBuffer,
-  bufferToHash
+  bufferToHash,
+  queryParamIsFalsy
 } = require('./util');
 
 class Service {
@@ -43,8 +44,8 @@ class Service {
       ...params.s3,
       VersionId: (query && query.VersionId) ? query.VersionId : undefined
     };
-    const returnBuffer = query && query.returnBuffer !== undefined ? query.returnBuffer : this.returnBuffer;
-    const returnUri = query && query.returnUri !== undefined ? query.returnUri : this.returnUri;
+    const returnBuffer = query && 'returnBuffer' in query ? !queryParamIsFalsy(query.returnBuffer) : this.returnBuffer;
+    const returnUri = query && 'returnUri' in query ? !queryParamIsFalsy(query.returnUri) : this.returnUri;
 
     const ext = extname(id);
     let contentType = mimeTypes.lookup(ext);
@@ -77,8 +78,8 @@ class Service {
 
   create (body, params = {}) {
     const { query } = params;
-    const returnBuffer = query && query.returnBuffer !== undefined ? query.returnBuffer : this.returnBuffer;
-    const returnUri = query && query.returnUri !== undefined ? query.returnUri : this.returnUri;
+    const returnBuffer = query && 'returnBuffer' in query ? !queryParamIsFalsy(query.returnBuffer) : this.returnBuffer;
+    const returnUri = query && 'returnUri' in query ? !queryParamIsFalsy(query.returnUri) : this.returnUri;
 
     let { id, uri, buffer, contentType } = body;
     if (uri) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,8 +21,3 @@ exports.bufferToHash = function bufferToHash (buffer) {
   hash.update(buffer);
   return hash.digest('hex');
 };
-
-exports.queryParamIsFalsy = function parseFalsyQueryParam (param) {
-  const str = (param || false).toString().trim().toLowerCase();
-  return ['false', '0', 'null', 'undefined'].includes(str);
-};

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,3 +21,8 @@ exports.bufferToHash = function bufferToHash (buffer) {
   hash.update(buffer);
   return hash.digest('hex');
 };
+
+exports.queryParamIsFalsy = function parseFalsyQueryParam (param) {
+  const str = (param || false).toString().trim().toLowerCase();
+  return ['false', '0', 'null', 'undefined'].includes(str);
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -263,6 +263,84 @@ describe('feathers-blob-store-basic', () => {
     }
   });
 
+  it('service operations overriding returnUri per request', async () => {
+    // default service with returnUri on
+    let store = BlobService({
+      Model: blobStore
+    });
+
+    // disable returnUri for create from buffer
+    let res = await store.create({ buffer: content, contentType }, { query: { returnUri: false } });
+    assert.strictEqual(res.uri, undefined);
+
+    // disable returnUri for create from uri
+    res = await store.create({ uri: contentUri }, { query: { returnUri: false } });
+    assert.strictEqual(res.uri, undefined);
+
+    // disable returnUri for get
+    res = await store.get(contentId, { query: { returnUri: false } });
+    assert.strictEqual(res.uri, undefined);
+
+    // service with default returnBuffer turned off
+    store = BlobService({
+      Model: blobStore,
+      returnBuffer: false,
+      returnUri: false
+    });
+
+    // enable returnUri for create from buffer
+    res = await store.create({ buffer: content, contentType }, { query: { returnUri: true } });
+    assert.strictEqual(res.uri, contentUri);
+
+    // enable returnUri for create from uri
+    res = await store.create({ uri: contentUri }, { query: { returnUri: true } });
+    assert.strictEqual(res.uri, contentUri);
+
+    // enable returnUri for get
+    res = await store.get(contentId, { query: { returnUri: true } });
+    assert.strictEqual(res.uri, contentUri);
+  });
+
+  it('service operations overriding returnBuffer per request', async () => {
+    // service with returnBuffer on
+    let store = BlobService({
+      Model: blobStore,
+      returnBuffer: true,
+      returnUri: false
+    });
+
+    // disable returnBuffer for create from buffer
+    let res = await store.create({ buffer: content, contentType }, { query: { returnBuffer: false } });
+    assert.strictEqual(res.buffer, undefined);
+
+    // disable returnBuffer for create from uri
+    res = await store.create({ uri: contentUri }, { query: { returnBuffer: false } });
+    assert.strictEqual(res.buffer, undefined);
+
+    // disable returnBuffer for get
+    res = await store.get(contentId, { query: { returnBuffer: false } });
+    assert.strictEqual(res.buffer, undefined);
+
+    // service with returnBuffer turned off
+    store = BlobService({
+      Model: blobStore,
+      returnBuffer: false,
+      returnUri: false
+    });
+
+    // enable returnBuffer for create from buffer
+    res = await store.create({ buffer: content, contentType }, { query: { returnBuffer: true } });
+    assert.strictEqual(res.buffer.equals(content), true);
+
+    // enable returnBuffer for create from uri
+    res = await store.create({ uri: contentUri }, { query: { returnBuffer: true } });
+    assert.strictEqual(res.buffer.equals(content), true);
+
+    // enable returnBuffer for get
+    res = await store.get(contentId, { query: { returnBuffer: true } });
+    assert.strictEqual(res.buffer.equals(content), true);
+  });
+
   it('service operations from client', (done) => {
     const blobStore = FsBlobStore(join(__dirname, 'blobs'));
     const store = BlobService({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -393,8 +393,7 @@ describe('feathers-blob-store-basic', () => {
 
       try {
         // test failing get
-        const result = await service.get(contentId);
-        console.log(result);
+        await service.get(contentId);
       } catch (err) {
         assert.ok(err, '.get() to non-existent id should error');
         done();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -372,13 +372,29 @@ describe('feathers-blob-store-basic', () => {
       assert.strictEqual(res.size, content.length);
       assert.strictEqual(res.contentType, contentType);
 
+      // test create with returnUri turned off without hook (no effect)
+      res = await service.create({ uri: contentUri }, { query: { returnUri: false } });
+      assert.strictEqual(res.uri, contentUri);
+
+      // test create with returnUri turned off with hook (works)
+      const storage = app.service('storage');
+      const { convertQueryOverrides } = require('../lib').hooks;
+      storage.hooks({
+        before: {
+          create: [convertQueryOverrides()]
+        }
+      });
+      res = await service.create({ uri: contentUri }, { query: { returnUri: false } });
+      assert.strictEqual(res.uri, undefined);
+
       // test successful remove
       res = await service.remove(contentId);
       assert.deepStrictEqual(res, { id: contentId });
 
       try {
         // test failing get
-        await service.get(contentId);
+        const result = await service.get(contentId);
+        console.log(result);
       } catch (err) {
         assert.ok(err, '.get() to non-existent id should error');
         done();

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -169,7 +169,5 @@ _describe('feathers-blob-store-s3', () => {
 
     assert.strictEqual(resGet1.uri, contentUri);
     assert.strictEqual(resGet2.uri, contentUri2);
-
-
   });
 });


### PR DESCRIPTION
### Summary

I'd like to be able to conditionally choose if a URI or a Buffer should be returned on some occasions, overriding the default global service setting.

This way, I can use a hook to set `returnBuffer` and `returnUri` by setting these props on `context.params`.