### PR TITLE
[remove] Pass s3 params to the call to Model.remove

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -131,11 +131,12 @@ class Service {
     });
   }
 
-  remove (id) {
+  remove (id, params = {}) {
     debug(`Removing blob ${id}`);
     return new Promise((resolve, reject) => {
       this.Model.remove({
-        key: id
+        key: id,
+        params: params.s3
       }, error => error ? reject(error) : resolve({ [this.id]: id }));
     });
   }


### PR DESCRIPTION
Hi,

I use this package with s3.

I encounter a bug when I try to remove a file in a Bucket other than the default one.

When I create a new object, the Bucket is well used, and my file go to the right one.

But when I remove it, passing the same `params.s3`, they are not taken in consideration.

Do you agree with this update ? Any wishes for documentation updates ?

I'm waiting for the PR https://github.com/jb55/s3-blob-store/pull/26 to be merged too, as it was not transmitted to the s3 client by the `s3-blob-store` package.